### PR TITLE
Switch back to gunicorn

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,5 +3,6 @@
 export CONFIG_PATH=/nevermined_metadata/config.ini
 export CONFIG_FILE=/nevermined_metadata/config.ini
 envsubst < /nevermined_metadata/config.ini.template > /nevermined_metadata/config.ini
-uwsgi --ini uwsgi.ini.template
+# uwsgi --ini uwsgi.ini.template
+gunicorn -b ${METADATA_URL#*://} -w ${METADATA_WORKERS} nevermined_metadata.run:app
 tail -f /dev/null


### PR DESCRIPTION
## Description

Python urllib fails when randomly when connecting to the metadata-api under `uwsgi` so switching back to `gunicorn` for now

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation
